### PR TITLE
Fix backward compatibility with C

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(smbios-parser)
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 if (UNIX)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wfatal-errors -fvisibility=hidden -Wfatal-errors -pedantic -std=c99 -Wl,--no-undefined -fPIC -Wall -Wextra -Wconversion -Werror=return-type -Werror=incompatible-pointer-types -Werror=sign-compare -Werror=sign-conversion")

--- a/smbios.c
+++ b/smbios.c
@@ -31,7 +31,7 @@ static SMBIOS_CONSTEXPR size_t SMBIOS_ENTRY_HEADER_SIZE = 4;
 
 #include <Windows.h>
 
-struct RawSMBIOSData
+typedef struct RawSMBIOSData
 {
 	BYTE    Used20CallingMethod;
 	BYTE    SMBIOSMajorVersion;
@@ -39,7 +39,7 @@ struct RawSMBIOSData
 	BYTE    DmiRevision;
 	DWORD   Length;
 	BYTE    SMBIOSTableData[];
-};
+} RawSMBIOSData;
 #endif
 
 int smbios_initialize(struct ParserContext *context, const uint8_t *data, size_t size, enum SpecVersion version )
@@ -92,7 +92,8 @@ int smbios_initialize(struct ParserContext *context, const uint8_t *data, size_t
     else
         return SMBERR_INVALID_DATA;
     #else
-    RawSMBIOSData *smBiosData = nullptr;
+
+    RawSMBIOSData *smBiosData = NULL;
     smBiosData = (RawSMBIOSData *) data;
 
     // get the SMBIOS version


### PR DESCRIPTION
Starting with CMake 3.27, there will be a warning for compat levels below CMake 3.5.
Everything else is a fix for compatibility with C code.