### PR TITLE
Fix SMBIOS version validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,11 @@ The pointer to the current SMBIOS entry is stored in the variable specified as t
 |TYPE_MANAGEMENT_DEVICE_THRESHOLD_DATA | management_device_threshold_data |
 |TYPE_ONBOARD_DEVICES_EXTENDED_INFO | onboard_devices_extended_info |
 
-The library do not make heap allocations: everything is done in-place using the provided SMBIOS buffer and the context.
+The library do not make heap allocations; everything is done in-place using the provided SMBIOS buffer and the context.
 
 ## API
 
-The following functions are available. If you're using the library in a C++ code, the functions will be defined in the `smbios` namespace.
+The following functions are available.
 
 ### smbios_initialize
 
@@ -93,7 +93,7 @@ If the actual version of the SMBIOS data is smaller than the value of the parame
 * **context**: Parser context.
 * **data**: SMBIOS data.
 * **size**: Size of the SMBIOS data.
-* **version**: Preferred SMBIOS version.
+* **version**: Preferred SMBIOS version. If set with `SMBIOS_ANY`, the latest version will be used (currently 3.0).
 
 The function returns SMBERR_OK on success or a negative error code.
 

--- a/smbios.c
+++ b/smbios.c
@@ -50,7 +50,7 @@ int smbios_initialize(struct ParserContext *context, const uint8_t *data, size_t
 
     memset(context, 0, sizeof(struct ParserContext));
     context->ptr = NULL;
-    context->sversion = VALID_VERSION(version) ? SMBIOS_3_0 : version;
+    context->sversion = VALID_VERSION(version) ? version : SMBIOS_3_0;
 
     // we have a valid SMBIOS entry point?
     #ifndef _WIN32
@@ -102,10 +102,12 @@ int smbios_initialize(struct ParserContext *context, const uint8_t *data, size_t
     context->size = smBiosData->Length;
     #endif
 
-    if (!VALID_VERSION(context->oversion))
-        return SMBERR_INVALID_DATA;
     if (context->sversion > context->oversion)
+    {
+        if (!VALID_VERSION(context->oversion))
+            return SMBERR_INVALID_DATA;
         context->sversion = context->oversion;
+    }
 
     return SMBERR_OK;
 }

--- a/smbios.h
+++ b/smbios.h
@@ -382,6 +382,7 @@ struct Entry
 
 enum SpecVersion
 {
+	SMBIOS_ANY = 0,
 	SMBIOS_2_0 = 0x0200,
 	SMBIOS_2_1 = 0x0201,
 	SMBIOS_2_2 = 0x0202,

--- a/smbios_decode.c
+++ b/smbios_decode.c
@@ -101,6 +101,8 @@ bool printSMBIOS( struct ParserContext *parser, FILE *output )
     if (smbios_get_version(parser, &version, NULL) != SMBERR_OK)
         return false;
 
+    fprintf(output, "SMBIOS version %d.%d\n", version >> 8, version & 0xFF);
+
     const struct Entry *entry = NULL;
     while (true)
     {
@@ -480,7 +482,7 @@ int main(int argc, char ** argv)
     }
 
     struct ParserContext parser;
-    if (smbios_initialize(&parser, buffer, size, SMBIOS_3_0) == SMBERR_OK)
+    if (smbios_initialize(&parser, buffer, size, SMBIOS_ANY) == SMBERR_OK)
         printSMBIOS(&parser, stdout);
     else
         fputs("Invalid SMBIOS data", stderr);


### PR DESCRIPTION
Fix bug in SMBIOS version validation as described in issue #16. I've updated the code to no longer use the `VALID_VERSION` macro for validation of the SMBIOS data version, which was how we did in previous C++ implementation. This change is necessary as the SMBIOS might be in a version not supported yet by the library.